### PR TITLE
#28 USWDS Component Radio Button (Based on Main)

### DIFF
--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.html
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.html
@@ -1,0 +1,19 @@
+<div class="usa-radio">
+  <input
+    #inputEl
+    [ngClass]="inputClasses()"
+    [id]="resolvedId()"
+    type="radio"
+    [name]="groupName()"
+    [value]="value()"
+    [checked]="checkedByDefault()"
+    [disabled]="disabled()"
+    (change)="onChange($event)"
+  />
+  <label class="usa-radio__label" [for]="resolvedId()">
+    {{ label() }}
+    @if (description()) {
+      <span class="usa-checkbox__label-description">{{ description() }}</span>
+    }
+  </label>
+</div>

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.scss
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.scss
@@ -1,0 +1,3 @@
+:host {
+  display: contents;
+}

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.spec.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.spec.ts
@@ -53,7 +53,7 @@ class DisabledHost {}
   imports: [UswdsRadioButton, UswdsRadioButtonItem],
   template: `
     <ngx-uswds-radio-button name="custom-id-group">
-      <ngx-uswds-radio-button-item label="Custom" value="custom" id="my-custom-id">
+      <ngx-uswds-radio-button-item label="Custom" value="custom" inputId="my-custom-id">
       </ngx-uswds-radio-button-item>
     </ngx-uswds-radio-button>
   `,

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.spec.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.spec.ts
@@ -1,0 +1,318 @@
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { UswdsRadioButtonItem } from './uswds-radio-button-item';
+import { UswdsRadioButton } from '../uswds-radio-button/uswds-radio-button';
+
+// Test Host Components
+
+@Component({
+  standalone: true,
+  imports: [UswdsRadioButton, UswdsRadioButtonItem],
+  template: `
+    <ngx-uswds-radio-button legend="Test Group" name="test-group" idPrefix="test">
+      <ngx-uswds-radio-button-item label="Option A" value="option-a" [checkedByDefault]="true">
+      </ngx-uswds-radio-button-item>
+      <ngx-uswds-radio-button-item label="Option B" value="option-b"> </ngx-uswds-radio-button-item>
+    </ngx-uswds-radio-button>
+  `,
+})
+class TwoItemHost {
+  @ViewChild(UswdsRadioButton) radio!: UswdsRadioButton;
+}
+
+@Component({
+  standalone: true,
+  imports: [UswdsRadioButton, UswdsRadioButtonItem],
+  template: `
+    <ngx-uswds-radio-button name="tile-group" variant="tile" idPrefix="tile">
+      <ngx-uswds-radio-button-item
+        label="Daily"
+        value="daily"
+        description="Receive updates every day"
+      >
+      </ngx-uswds-radio-button-item>
+    </ngx-uswds-radio-button>
+  `,
+})
+class TileHost {}
+
+@Component({
+  standalone: true,
+  imports: [UswdsRadioButton, UswdsRadioButtonItem],
+  template: `
+    <ngx-uswds-radio-button name="disabled-group" idPrefix="dis">
+      <ngx-uswds-radio-button-item label="Locked" value="locked" [disabled]="true">
+      </ngx-uswds-radio-button-item>
+    </ngx-uswds-radio-button>
+  `,
+})
+class DisabledHost {}
+
+@Component({
+  standalone: true,
+  imports: [UswdsRadioButton, UswdsRadioButtonItem],
+  template: `
+    <ngx-uswds-radio-button name="custom-id-group">
+      <ngx-uswds-radio-button-item label="Custom" value="custom" id="my-custom-id">
+      </ngx-uswds-radio-button-item>
+    </ngx-uswds-radio-button>
+  `,
+})
+class CustomIdHost {}
+
+@Component({
+  standalone: true,
+  imports: [UswdsRadioButton, UswdsRadioButtonItem],
+  template: `
+    <ngx-uswds-radio-button name="event-group" idPrefix="evt">
+      <ngx-uswds-radio-button-item label="Toggle Me" value="toggle"> </ngx-uswds-radio-button-item>
+    </ngx-uswds-radio-button>
+  `,
+})
+class EventHost {
+  @ViewChild(UswdsRadioButtonItem) item!: UswdsRadioButtonItem;
+}
+
+// Helpers
+
+function getInput(nativeEl: HTMLElement, index = 0): HTMLInputElement {
+  return nativeEl.querySelectorAll<HTMLInputElement>('input[type="radio"]')[index];
+}
+
+function getLabel(nativeEl: HTMLElement, index = 0): HTMLLabelElement {
+  return nativeEl.querySelectorAll<HTMLLabelElement>('label.usa-radio__label')[index];
+}
+
+// Test Suite
+
+describe('UswdsRadioButtonItem', () => {
+  describe('Default rendering', () => {
+    let fixture: ComponentFixture<TwoItemHost>;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [TwoItemHost],
+      }).compileComponents();
+      fixture = TestBed.createComponent(TwoItemHost);
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(fixture.componentInstance).toBeTruthy();
+    });
+
+    it('should render a div.usa-radio wrapper', () => {
+      const wrappers = fixture.nativeElement.querySelectorAll('div.usa-radio');
+      expect(wrappers.length).toBe(2);
+    });
+
+    it('should render the label text', () => {
+      expect(getLabel(fixture.nativeElement, 0).textContent?.trim()).toBe('Option A');
+      expect(getLabel(fixture.nativeElement, 1).textContent?.trim()).toBe('Option B');
+    });
+
+    it('should render the value attribute on the input', () => {
+      expect(getInput(fixture.nativeElement, 0).value).toBe('option-a');
+      expect(getInput(fixture.nativeElement, 1).value).toBe('option-b');
+    });
+
+    it('should render the pre-selected item as checked', () => {
+      expect(getInput(fixture.nativeElement, 0).checked).toBe(true);
+    });
+
+    it('should render the unselected item as unchecked', () => {
+      expect(getInput(fixture.nativeElement, 1).checked).toBe(false);
+    });
+
+    it('should apply usa-radio__input class to inputs', () => {
+      const inputs = fixture.nativeElement.querySelectorAll('input.usa-radio__input');
+      expect(inputs.length).toBe(2);
+    });
+
+    it('should not apply tile class in default variant', () => {
+      const tileInputs = fixture.nativeElement.querySelectorAll('input.usa-radio__input--tile');
+      expect(tileInputs.length).toBe(0);
+    });
+
+    it('should set the name attribute from the radio button group', () => {
+      const el = fixture.nativeElement as HTMLElement;
+      const inputs = el.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+      inputs.forEach((input: HTMLInputElement) => {
+        expect(input.name).toBe('test-group');
+      });
+    });
+
+    it('should link each input id to its label for attribute', () => {
+      const el = fixture.nativeElement as HTMLElement;
+      const inputs = el.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+      inputs.forEach((input: HTMLInputElement) => {
+        const label = el.querySelector(`label[for="${input.id}"]`);
+        expect(label).toBeTruthy();
+      });
+    });
+
+    it('should auto-generate ids from the radio button idPrefix', () => {
+      expect(getInput(fixture.nativeElement, 0).id).toBe('test-1');
+      expect(getInput(fixture.nativeElement, 1).id).toBe('test-2');
+    });
+  });
+
+  describe('Tile variant', () => {
+    let fixture: ComponentFixture<TileHost>;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [TileHost],
+      }).compileComponents();
+      fixture = TestBed.createComponent(TileHost);
+      fixture.detectChanges();
+    });
+
+    it('should apply usa-radio__input--tile class', () => {
+      expect(getInput(fixture.nativeElement).classList).toContain('usa-radio__input--tile');
+    });
+
+    it('should render the description span', () => {
+      const desc = fixture.nativeElement.querySelector('span.usa-checkbox__label-description');
+      expect(desc).toBeTruthy();
+      expect(desc.textContent?.trim()).toBe('Receive updates every day');
+    });
+  });
+
+  describe('Disabled state', () => {
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [DisabledHost],
+      }).compileComponents();
+    });
+
+    it('should render the input as disabled', () => {
+      const fixture = TestBed.createComponent(DisabledHost);
+      fixture.detectChanges();
+      expect(getInput(fixture.nativeElement).disabled).toBe(true);
+    });
+  });
+
+  describe('Custom id', () => {
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [CustomIdHost],
+      }).compileComponents();
+    });
+
+    it('should use the provided id on the input', () => {
+      const fixture = TestBed.createComponent(CustomIdHost);
+      fixture.detectChanges();
+      expect(getInput(fixture.nativeElement).id).toBe('my-custom-id');
+    });
+
+    it('should use the provided id on the label for attribute', () => {
+      const fixture = TestBed.createComponent(CustomIdHost);
+      fixture.detectChanges();
+      const label = fixture.nativeElement.querySelector('label');
+      expect(label?.getAttribute('for')).toBe('my-custom-id');
+    });
+  });
+
+  describe('checked getter/setter and getInputElement()', () => {
+    let fixture: ComponentFixture<EventHost>;
+    let item: UswdsRadioButtonItem;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [EventHost],
+      }).compileComponents();
+      fixture = TestBed.createComponent(EventHost);
+      fixture.detectChanges();
+      item = fixture.componentInstance.item;
+    });
+
+    it('should return false from checked getter when unselected', () => {
+      expect(item.checked).toBe(false);
+    });
+
+    it('should update the native input when the checked setter is called', () => {
+      item.checked = true;
+      expect(getInput(fixture.nativeElement).checked).toBe(true);
+    });
+
+    it('should reflect the updated state via the checked getter after setting', () => {
+      item.checked = true;
+      expect(item.checked).toBe(true);
+    });
+
+    it('should return the native HTMLInputElement from getInputElement()', () => {
+      const nativeInput = item.getInputElement();
+      expect(nativeInput).toBeInstanceOf(HTMLInputElement);
+      expect(nativeInput.type).toBe('radio');
+    });
+  });
+
+  describe('selectedChange output', () => {
+    let fixture: ComponentFixture<EventHost>;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [EventHost],
+      }).compileComponents();
+      fixture = TestBed.createComponent(EventHost);
+      fixture.detectChanges();
+    });
+
+    it('should emit true when the radio button is selected', () => {
+      let emitted: boolean | undefined;
+      fixture.componentInstance.item.selectedChange.subscribe((v) => (emitted = v));
+
+      const input = getInput(fixture.nativeElement);
+      input.checked = true;
+      input.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+
+      expect(emitted).toBe(true);
+    });
+
+    it('should emit false when the radio button is deselected', () => {
+      let emitted: boolean | undefined;
+      fixture.componentInstance.item.selectedChange.subscribe((v) => (emitted = v));
+
+      const input = getInput(fixture.nativeElement);
+      input.checked = false;
+      input.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+
+      expect(emitted).toBe(false);
+    });
+  });
+
+  describe('inputClasses', () => {
+    it('should include usa-radio__input but not tile class for default variant', async () => {
+      await TestBed.configureTestingModule({ imports: [TwoItemHost] }).compileComponents();
+      const fixture = TestBed.createComponent(TwoItemHost);
+      fixture.detectChanges();
+
+      const items = fixture.componentInstance.radio.items();
+      expect(items[0].inputClasses()).toContain('usa-radio__input');
+      expect(items[0].inputClasses()).not.toContain('usa-radio__input--tile');
+    });
+
+    it('should include tile class for tile variant', async () => {
+      await TestBed.configureTestingModule({ imports: [TileHost] }).compileComponents();
+      const fixture = TestBed.createComponent(TileHost);
+      fixture.detectChanges();
+
+      const inputs = fixture.nativeElement.querySelectorAll('input.usa-radio__input--tile');
+      expect(inputs.length).toBe(1);
+    });
+  });
+
+  describe('no description', () => {
+    it('should not render description span when description is not provided', async () => {
+      await TestBed.configureTestingModule({ imports: [TwoItemHost] }).compileComponents();
+      const fixture = TestBed.createComponent(TwoItemHost);
+      fixture.detectChanges();
+
+      const desc = fixture.nativeElement.querySelector('span.usa-checkbox__label-description');
+      expect(desc).toBeFalsy();
+    });
+  });
+});

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.ts
@@ -1,0 +1,127 @@
+import {
+  Component,
+  ElementRef,
+  ViewChild,
+  input,
+  output,
+  signal,
+  computed,
+  inject,
+} from '@angular/core';
+import { NgClass } from '@angular/common';
+import { UswdsRadioButton } from '../uswds-radio-button/uswds-radio-button';
+
+/**
+ * @class UswdsRadioButtonItem
+ * @description
+ * A child component of `<ngx-uswds-radio-button>` that renders a single radio button input.
+ * The native `<input type="radio">` is defined inside this component and is accessible
+ * via `getInputElement()`. Use the `checked` getter to read the selected state.
+ *
+ * The `name` attribute and visual variant are inherited from the parent radio button component.
+ * Because radio buttons are mutually exclusive within a group, only one item may be
+ * selected at a time.
+ *
+ * @selector ngx-uswds-radio-button-item
+ *
+ * @example
+ * <ngx-uswds-radio-button legend="Select one historical figure" name="historical-figures">
+ *   <ngx-uswds-radio-button-item label="Sojourner Truth" value="sojourner-truth" [checkedByDefault]="true">
+ *   </ngx-uswds-radio-button-item>
+ *   <ngx-uswds-radio-button-item label="Frederick Douglass" value="frederick-douglass">
+ *   </ngx-uswds-radio-button-item>
+ * </ngx-uswds-radio-button>
+ *
+ * @input {string} label - The visible label text rendered next to the radio button. Required.
+ *
+ * @input {string} value - The value submitted with the form when this radio button is selected. Required.
+ *
+ * @input {boolean} [disabled=false] - When true, the radio button is rendered as disabled.
+ *
+ * @input {string} [description] - Optional description text shown below the label (tile variant).
+ *
+ * @input {boolean} [checkedByDefault=false] - When true, this radio button is pre-selected on render.
+ *   Only one item in a group should have this set to true.
+ *
+ * @input {string} [id] - Custom id for the input/label pair. When not provided, an id is
+ *   auto-generated from the parent radio button's id prefix and this item's index.
+ *
+ * @output {boolean} selectedChange - Emits the new selected state whenever the radio button changes.
+ */
+@Component({
+  selector: 'ngx-uswds-radio-button-item',
+  standalone: true,
+  imports: [NgClass],
+  templateUrl: './uswds-radio-button-item.html',
+  styleUrl: './uswds-radio-button-item.scss',
+})
+export class UswdsRadioButtonItem {
+  // v8 ignore next
+  label = input.required<string>();
+  // v8 ignore next
+  value = input.required<string>();
+  // v8 ignore next
+  disabled = input<boolean>(false);
+  // v8 ignore next
+  description = input<string>();
+  // v8 ignore next
+  checkedByDefault = input<boolean>(false);
+  // v8 ignore next
+  id = input<string>();
+
+  selectedChange = output<boolean>();
+
+  // Assigned by the parent UswdsRadioButton after content initialization. Not intended to
+  // be set externally — use the `checkedByDefault` and `id` inputs to configure this item.
+  // v8 ignore next
+  readonly _index = signal<number>(-1);
+
+  /** Read-only view of this item's position within the radio button group. */
+  // v8 ignore next
+  readonly index = this._index.asReadonly();
+
+  // v8 ignore next
+  private radioButton = inject(UswdsRadioButton);
+
+  // v8 ignore next 2
+  @ViewChild('inputEl')
+  private inputRef!: ElementRef<HTMLInputElement>;
+
+  // v8 ignore next
+  resolvedId = computed(
+    () => this.id() ?? `${this.radioButton.resolvedIdPrefix()}-${this.index() + 1}`,
+  );
+
+  // v8 ignore next
+  readonly groupName = computed(() => this.radioButton.name());
+
+  // v8 ignore next
+  inputClasses = computed(() => this.inputClassesFn());
+  inputClassesFn = () => {
+    const classes = ['usa-radio__input'];
+    if (this.radioButton.variant() === 'tile') {
+      classes.push('usa-radio__input--tile');
+    }
+    return classes;
+  };
+
+  /** Returns the current selected state of the native input element. */
+  get checked(): boolean {
+    return this.inputRef.nativeElement.checked;
+  }
+
+  /** Sets the selected state of the native input element. */
+  set checked(val: boolean) {
+    this.inputRef.nativeElement.checked = val;
+  }
+
+  /** Returns the native `<input type="radio">` element. */
+  getInputElement(): HTMLInputElement {
+    return this.inputRef.nativeElement;
+  }
+
+  onChange(event: Event): void {
+    const checked = (event.target as HTMLInputElement).checked;
+    this.selectedChange.emit(checked);
+  }
+}

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.ts
@@ -43,7 +43,7 @@ import { UswdsRadioButton } from '../uswds-radio-button/uswds-radio-button';
  * @input {boolean} [checkedByDefault=false] - When true, this radio button is pre-selected on render.
  *   Only one item in a group should have this set to true.
  *
- * @input {string} [id] - Custom id for the input/label pair. When not provided, an id is
+ * @input {string} [inputId] - Custom id for the input/label pair. When not provided, an id is
  *   auto-generated from the parent radio button's id prefix and this item's index.
  *
  * @output {boolean} selectedChange - Emits the new selected state whenever the radio button changes.
@@ -67,7 +67,7 @@ export class UswdsRadioButtonItem {
   // v8 ignore next
   checkedByDefault = input<boolean>(false);
   // v8 ignore next
-  id = input<string>();
+  inputId = input<string>();
 
   selectedChange = output<boolean>();
 
@@ -89,7 +89,7 @@ export class UswdsRadioButtonItem {
 
   // v8 ignore next
   resolvedId = computed(
-    () => this.id() ?? `${this.radioButton.resolvedIdPrefix()}-${this.index() + 1}`,
+    () => this.inputId() ?? `${this.radioButton.resolvedIdPrefix()}-${this.index() + 1}`,
   );
 
   // v8 ignore next

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.ts
@@ -71,8 +71,6 @@ export class UswdsRadioButtonItem {
 
   selectedChange = output<boolean>();
 
-  // Assigned by the parent UswdsRadioButton after content initialization. Not intended to
-  // be set externally — use the `checkedByDefault` and `id` inputs to configure this item.
   // v8 ignore next
   readonly _index = signal<number>(-1);
 

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button/radio-button-types.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button/radio-button-types.ts
@@ -1,0 +1,1 @@
+export type RadioButtonVariant = 'default' | 'tile';

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button/uswds-radio-button.html
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button/uswds-radio-button.html
@@ -1,0 +1,4 @@
+<fieldset class="usa-fieldset">
+  <legend class="usa-legend">{{ legend() }}</legend>
+  <ng-content></ng-content>
+</fieldset>

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button/uswds-radio-button.scss
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button/uswds-radio-button.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button/uswds-radio-button.spec.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button/uswds-radio-button.spec.ts
@@ -1,0 +1,284 @@
+import { Component, ViewChild, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { UswdsRadioButton } from './uswds-radio-button';
+import { UswdsRadioButtonItem } from '../uswds-radio-button-item/uswds-radio-button-item';
+
+// Test Host Components
+
+@Component({
+  standalone: true,
+  imports: [UswdsRadioButton, UswdsRadioButtonItem],
+  template: `
+    <ngx-uswds-radio-button [legend]="legend()" [name]="name" [idPrefix]="idPrefix">
+      <ngx-uswds-radio-button-item
+        label="Sojourner Truth"
+        value="sojourner-truth"
+        [checkedByDefault]="true"
+      >
+      </ngx-uswds-radio-button-item>
+      <ngx-uswds-radio-button-item label="Frederick Douglass" value="frederick-douglass">
+      </ngx-uswds-radio-button-item>
+      <ngx-uswds-radio-button-item label="Booker T. Washington" value="booker-t-washington">
+      </ngx-uswds-radio-button-item>
+    </ngx-uswds-radio-button>
+  `,
+})
+class ThreeItemHost {
+  legend = signal('Select one historical figure');
+  name = 'historical-figures';
+  idPrefix?: string;
+  @ViewChild(UswdsRadioButton) radio!: UswdsRadioButton;
+}
+
+@Component({
+  standalone: true,
+  imports: [UswdsRadioButton, UswdsRadioButtonItem],
+  template: `
+    <ngx-uswds-radio-button legend="Tile Group" name="tile-group" variant="tile" idPrefix="tile">
+      <ngx-uswds-radio-button-item
+        label="Daily"
+        value="daily"
+        [checkedByDefault]="true"
+        description="Sent every day"
+      >
+      </ngx-uswds-radio-button-item>
+      <ngx-uswds-radio-button-item label="Weekly" value="weekly" description="Sent once a week">
+      </ngx-uswds-radio-button-item>
+    </ngx-uswds-radio-button>
+  `,
+})
+class TileHost {
+  @ViewChild(UswdsRadioButton) radio!: UswdsRadioButton;
+}
+
+@Component({
+  standalone: true,
+  imports: [UswdsRadioButton],
+  template: `<ngx-uswds-radio-button legend="Empty" name="empty"></ngx-uswds-radio-button>`,
+})
+class EmptyHost {
+  @ViewChild(UswdsRadioButton) radio!: UswdsRadioButton;
+}
+
+// Helpers
+
+function getInputs(nativeEl: HTMLElement): NodeListOf<HTMLInputElement> {
+  return (nativeEl as HTMLElement).querySelectorAll<HTMLInputElement>('input[type="radio"]');
+}
+
+// Test Suite
+
+describe('UswdsRadioButton', () => {
+  describe('with three items (default config)', () => {
+    let fixture: ComponentFixture<ThreeItemHost>;
+    let host: ThreeItemHost;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [ThreeItemHost],
+      }).compileComponents();
+      fixture = TestBed.createComponent(ThreeItemHost);
+      host = fixture.componentInstance;
+      host.idPrefix = 'hist';
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(host.radio).toBeTruthy();
+    });
+
+    describe('Default values', () => {
+      it('should default variant to "default"', () => {
+        expect(host.radio.variant()).toBe('default');
+      });
+
+      it('should discover three content children', () => {
+        expect(host.radio.items().length).toBe(3);
+      });
+    });
+
+    describe('DOM rendering', () => {
+      it('should render a fieldset with usa-fieldset class', () => {
+        expect(fixture.nativeElement.querySelector('fieldset.usa-fieldset')).toBeTruthy();
+      });
+
+      it('should render the legend text', () => {
+        const legend = fixture.nativeElement.querySelector('legend.usa-legend');
+        expect(legend?.textContent?.trim()).toBe('Select one historical figure');
+      });
+
+      it('should render the correct number of radio buttons', () => {
+        expect(getInputs(fixture.nativeElement).length).toBe(3);
+      });
+
+      it('should render usa-radio wrappers for each item', () => {
+        const wrappers = fixture.nativeElement.querySelectorAll('div.usa-radio');
+        expect(wrappers.length).toBe(3);
+      });
+
+      it('should propagate the name to all inputs', () => {
+        getInputs(fixture.nativeElement).forEach((input: HTMLInputElement) => {
+          expect(input.name).toBe('historical-figures');
+        });
+      });
+    });
+
+    describe('Index assignment', () => {
+      it('should assign sequential indices to all items after content init', () => {
+        const items = host.radio.items();
+        expect(items[0].index()).toBe(0);
+        expect(items[1].index()).toBe(1);
+        expect(items[2].index()).toBe(2);
+      });
+    });
+
+    describe('ID generation', () => {
+      it('should use provided idPrefix for all input IDs', () => {
+        expect(getInputs(fixture.nativeElement)[0].id).toBe('hist-1');
+        expect(getInputs(fixture.nativeElement)[1].id).toBe('hist-2');
+        expect(getInputs(fixture.nativeElement)[2].id).toBe('hist-3');
+      });
+
+      it('should auto-generate unique idPrefixes when not provided', () => {
+        const f1 = TestBed.createComponent(ThreeItemHost);
+        f1.detectChanges();
+        const prefix1 = f1.componentInstance.radio.resolvedIdPrefix();
+
+        const f2 = TestBed.createComponent(ThreeItemHost);
+        f2.detectChanges();
+        const prefix2 = f2.componentInstance.radio.resolvedIdPrefix();
+
+        expect(prefix1).toMatch(/^radio-button-\d+$/);
+        expect(prefix2).toMatch(/^radio-button-\d+$/);
+        expect(prefix1).not.toBe(prefix2);
+      });
+    });
+
+    describe('Accessibility', () => {
+      it('should use a fieldset to group the radio buttons', () => {
+        expect(fixture.nativeElement.querySelector('fieldset')).toBeTruthy();
+      });
+
+      it('should use a legend inside the fieldset', () => {
+        expect(fixture.nativeElement.querySelector('fieldset legend')).toBeTruthy();
+      });
+
+      it('should link each input id to its label for attribute', () => {
+        const el = fixture.nativeElement as HTMLElement;
+        const inputs = el.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+        inputs.forEach((input: HTMLInputElement) => {
+          const label = el.querySelector(`label[for="${input.id}"]`);
+          expect(label).toBeTruthy();
+        });
+      });
+    });
+
+    describe('Legend update', () => {
+      it('should update the rendered legend when the legend input changes', () => {
+        host.legend.set('Updated Legend');
+        fixture.detectChanges();
+
+        const legend = fixture.nativeElement.querySelector('legend.usa-legend');
+        expect(legend?.textContent?.trim()).toBe('Updated Legend');
+      });
+    });
+  });
+
+  describe('Tile variant', () => {
+    let fixture: ComponentFixture<TileHost>;
+    let host: TileHost;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [TileHost],
+      }).compileComponents();
+      fixture = TestBed.createComponent(TileHost);
+      host = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should apply usa-radio__input--tile class to all inputs', () => {
+      const tileInputs = fixture.nativeElement.querySelectorAll('input.usa-radio__input--tile');
+      expect(tileInputs.length).toBe(2);
+    });
+
+    it('should render description spans when items have descriptions', () => {
+      const descs = fixture.nativeElement.querySelectorAll('span.usa-checkbox__label-description');
+      expect(descs.length).toBe(2);
+    });
+
+    it('should render the first item as checked', () => {
+      expect(getInputs(fixture.nativeElement)[0].checked).toBe(true);
+    });
+
+    it('should expose variant as "tile"', () => {
+      expect(host.radio.variant()).toBe('tile');
+    });
+  });
+
+  describe('Empty radio group', () => {
+    it('should render fieldset with no radio buttons when no items are projected', async () => {
+      await TestBed.configureTestingModule({
+        imports: [EmptyHost],
+      }).compileComponents();
+      const fixture = TestBed.createComponent(EmptyHost);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('fieldset')).toBeTruthy();
+      expect(getInputs(fixture.nativeElement).length).toBe(0);
+    });
+
+    it('should have zero items', async () => {
+      await TestBed.configureTestingModule({
+        imports: [EmptyHost],
+      }).compileComponents();
+      const fixture = TestBed.createComponent(EmptyHost);
+      fixture.detectChanges();
+      expect(fixture.componentInstance.radio.items().length).toBe(0);
+    });
+  });
+
+  describe('getSelectedItem / getUnselectedItems', () => {
+    let fixture: ComponentFixture<ThreeItemHost>;
+    let host: ThreeItemHost;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [ThreeItemHost],
+      }).compileComponents();
+      fixture = TestBed.createComponent(ThreeItemHost);
+      host = fixture.componentInstance;
+      host.idPrefix = 'sel';
+      fixture.detectChanges();
+    });
+
+    it('should return the pre-selected item from getSelectedItem', () => {
+      const selected = host.radio.getSelectedItem();
+      expect(selected).not.toBeNull();
+      expect(selected!.value()).toBe('sojourner-truth');
+    });
+
+    it('should return the remaining items in getUnselectedItems', () => {
+      const unselected = host.radio.getUnselectedItems();
+      expect(unselected.length).toBe(2);
+    });
+
+    it('should return null from getSelectedItem when no item is selected', async () => {
+      await TestBed.configureTestingModule({
+        imports: [EmptyHost],
+      }).compileComponents();
+      const emptyFixture = TestBed.createComponent(EmptyHost);
+      emptyFixture.detectChanges();
+      expect(emptyFixture.componentInstance.radio.getSelectedItem()).toBeNull();
+    });
+
+    it('should reflect a programmatic checked change', () => {
+      const items = host.radio.items();
+      items[0].checked = false;
+      items[1].checked = true;
+
+      expect(host.radio.getSelectedItem()?.value()).toBe('frederick-douglass');
+      expect(host.radio.getUnselectedItems().length).toBe(2);
+    });
+  });
+});

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button/uswds-radio-button.spec.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button/uswds-radio-button.spec.ts
@@ -236,6 +236,15 @@ describe('UswdsRadioButton', () => {
       fixture.detectChanges();
       expect(fixture.componentInstance.radio.items().length).toBe(0);
     });
+
+    it('should return null from getSelectedItem when no item is selected', async () => {
+      await TestBed.configureTestingModule({
+        imports: [EmptyHost],
+      }).compileComponents();
+      const emptyFixture = TestBed.createComponent(EmptyHost);
+      emptyFixture.detectChanges();
+      expect(emptyFixture.componentInstance.radio.getSelectedItem()).toBeNull();
+    });
   });
 
   describe('getSelectedItem / getUnselectedItems', () => {
@@ -261,15 +270,6 @@ describe('UswdsRadioButton', () => {
     it('should return the remaining items in getUnselectedItems', () => {
       const unselected = host.radio.getUnselectedItems();
       expect(unselected.length).toBe(2);
-    });
-
-    it('should return null from getSelectedItem when no item is selected', async () => {
-      await TestBed.configureTestingModule({
-        imports: [EmptyHost],
-      }).compileComponents();
-      const emptyFixture = TestBed.createComponent(EmptyHost);
-      emptyFixture.detectChanges();
-      expect(emptyFixture.componentInstance.radio.getSelectedItem()).toBeNull();
     });
 
     it('should reflect a programmatic checked change', () => {

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button/uswds-radio-button.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-radio-button/uswds-radio-button.ts
@@ -1,0 +1,105 @@
+import {
+  Component,
+  input,
+  signal,
+  ContentChildren,
+  QueryList,
+  AfterContentInit,
+} from '@angular/core';
+import { UswdsRadioButtonItem } from '../uswds-radio-button-item/uswds-radio-button-item';
+import { RadioButtonVariant } from './radio-button-types';
+
+/**
+ * @class UswdsRadioButton
+ * @description
+ * An Angular standalone component that renders a U.S. Web Design System (USWDS) radio button group.
+ * Radio buttons allow users to select exactly one choice from a group.
+ *
+ * Uses a compound component pattern: place one or more `<ngx-uswds-radio-button-item>` elements as
+ * direct children. Each item renders its own `<input type="radio">` and label, with the
+ * `name` attribute and visual variant inherited from this component.
+ *
+ * @selector ngx-uswds-radio-button
+ *
+ * @example
+ * <ngx-uswds-radio-button legend="Select one historical figure" name="historical-figures">
+ *   <ngx-uswds-radio-button-item label="Sojourner Truth" value="sojourner-truth" [checkedByDefault]="true">
+ *   </ngx-uswds-radio-button-item>
+ *   <ngx-uswds-radio-button-item label="Frederick Douglass" value="frederick-douglass">
+ *   </ngx-uswds-radio-button-item>
+ * </ngx-uswds-radio-button>
+ *
+ * @example
+ * <!-- Tile variant with descriptions -->
+ * <ngx-uswds-radio-button legend="Choose a frequency" name="freq" variant="tile">
+ *   <ngx-uswds-radio-button-item label="Daily" value="daily" description="Sent every day">
+ *   </ngx-uswds-radio-button-item>
+ *   <ngx-uswds-radio-button-item label="Weekly" value="weekly" description="Sent once a week">
+ *   </ngx-uswds-radio-button-item>
+ * </ngx-uswds-radio-button>
+ *
+ * @input {string} [legend=''] - The legend text for the radio button fieldset group.
+ *
+ * @input {string} [name=''] - The `name` attribute shared across all radio buttons in the group.
+ *   All radio buttons sharing the same `name` are mutually exclusive.
+ *
+ * @input {RadioButtonVariant} [variant='default'] - The display variant. Use 'tile' for larger
+ *   tile-style radio buttons with optional description text.
+ *
+ * @input {string} [idPrefix] - Custom prefix for generated element IDs. If not provided,
+ *   a unique prefix is auto-generated to avoid ID collisions between multiple radio groups
+ *   on the same page.
+ */
+@Component({
+  selector: 'ngx-uswds-radio-button',
+  standalone: true,
+  templateUrl: './uswds-radio-button.html',
+  styleUrl: './uswds-radio-button.scss',
+})
+export class UswdsRadioButton implements AfterContentInit {
+  // v8 ignore next
+  legend = input<string>('');
+  // v8 ignore next
+  name = input<string>('');
+  // v8 ignore next
+  variant = input<RadioButtonVariant>('default');
+  // v8 ignore next
+  idPrefix = input<string>();
+
+  // v8 ignore next
+  resolvedIdPrefix = signal<string>('');
+
+  // v8 ignore next 2
+  @ContentChildren(UswdsRadioButtonItem)
+  itemList!: QueryList<UswdsRadioButtonItem>;
+
+  items(): UswdsRadioButtonItem[] {
+    return this.itemList.toArray();
+  }
+
+  /** Returns the currently selected item, or null if none is selected. */
+  getSelectedItem(): UswdsRadioButtonItem | null {
+    return this.items().find((item) => item.checked) ?? null;
+  }
+
+  /** Returns all items that are not currently selected. */
+  getUnselectedItems(): UswdsRadioButtonItem[] {
+    return this.items().filter((item) => !item.checked);
+  }
+
+  private static instanceCounter = 0;
+
+  ngAfterContentInit(): void {
+    this.resolvedIdPrefix.set(this.idPrefix() ?? this.generateUniquePrefix());
+    this.assignIndices();
+  }
+
+  private assignIndices(): void {
+    this.items().forEach((item, i) => item._index.set(i));
+  }
+
+  private generateUniquePrefix(): string {
+    UswdsRadioButton.instanceCounter++;
+    return `radio-button-${UswdsRadioButton.instanceCounter}`;
+  }
+}

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/public-api.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/public-api.ts
@@ -19,3 +19,8 @@ export type { AccordionVariant } from './components/uswds-accordion/accordion-ty
 // Breadcrumb Component
 export * from './components/uswds-breadcrumb/uswds-breadcrumb';
 export type { BreadcrumbVariant } from './components/uswds-breadcrumb/uswds-breadcrumb';
+
+// Radio Button Component
+export * from './components/uswds-radio-button/uswds-radio-button';
+export * from './components/uswds-radio-button-item/uswds-radio-button-item';
+export type { RadioButtonVariant } from './components/uswds-radio-button/radio-button-types';


### PR DESCRIPTION
## Description
This tackles issue #28.
This PR implements the USWDS Radio Button component for Angular using a compound component pattern, providing UswdsRadioButton as the group container and UswdsRadioButtonItem as the individual option.

## Code Changes
New Files:
- `ngx-uswds-lib/src/components/uswds-radio-button/uswds-radio-button.ts`: Parent container component with legend, name, variant, and idPrefix inputs; ContentChildren-based item discovery; getSelectedItem() and getUnselectedItems() methods; auto-generated unique ID prefixes via static instance counter
- `ngx-uswds-lib/src/components/uswds-radio-button/uswds-radio-button.html`: Fieldset/legend template with <ng-content> projection for child items
- `ngx-uswds-lib/src/components/uswds-radio-button/uswds-radio-button.scss`: Component-specific styles
- `ngx-uswds-lib/src/components/uswds-radio-button/radio-button-types.ts`: RadioButtonVariant type ('default' | 'tile')
- `ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.ts`: Child item component with required label and value inputs; optional disabled, description, checkedByDefault, and inputId inputs; selectedChange output; computed resolvedId and inputClasses; checked getter/setter and getInputElement() method
- `ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.html`: Individual radio input/label template with conditional description span for tile variant
- `ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.scss`: Item-specific styles (display: contents to avoid extra DOM wrappers)
- `ngx-uswds-lib/src/components/uswds-radio-button/uswds-radio-button.spec.ts`: Unit tests for the group component
- `ngx-uswds-lib/src/components/uswds-radio-button-item/uswds-radio-button-item.spec.ts`: Unit tests for the item component

Modified Files:
- `ngx-uswds-lib/src/public-api.ts`: Added exports for both components and RadioButtonVariant type


## Testing
Unit Testing:
- Confirm all unit tests are passing
- Run ng test (with --coverage) command in ngx-uswds-workspace
- `uswds-radio-button.spec.ts` covers:
  - Default values (variant='default', content children discovery)
  - DOM rendering: fieldset, legend, correct number of radio buttons, usa-radio wrappers, name attribute propagation
  - Index assignment: sequential 0-based indices set on child items
  - ID generation: uses provided idPrefix, auto-generates unique prefix when not provided
  - Accessibility: fieldset grouping, legend inside fieldset, input id linked to label for attribute
  - Reactive legend updates
  - Tile variant: usa-radio__input--tile class, description spans, first item checked by default
  - Empty group: fieldset renders with zero items, getSelectedItem() returns null
  - Selection methods: getSelectedItem(), getUnselectedItems(), programmatic checked changes
- `uswds-radio-button-item.spec.ts` covers:
  - Default rendering: wrapper class, label, value, checked/unchecked state, CSS classes, name and id attributes
  - Auto-generated IDs from parent idPrefix
  - Tile variant: usa-radio__input--tile class, description span present/absent
  - Disabled state
  - Custom inputId on input and label for
  - checked getter/setter and getInputElement()
  - selectedChange emits true/false on change events
  - inputClasses computed for default and tile variants

Manual Testing:
- Using the demo app (don't forget to add imports in app.ts)
- In app.html, can try these examples (which can be cross referenced with the USWDS site examples):

```ts
  <h2>Radio Buttons — Default</h2>
  <p>First item pre-selected; last item disabled.</p>

  <ngx-uswds-radio-button legend="Select one historical figure" name="historical-figures" idPrefix="default-demo">
    <ngx-uswds-radio-button-item
      label="Sojourner Truth"
      value="sojourner-truth"
      [checkedByDefault]="true"
    ></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item
      label="Frederick Douglass"
      value="frederick-douglass"
    ></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item
      label="Booker T. Washington"
      value="booker-t-washington"
    ></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item
      label="George Washington Carver"
      value="george-washington-carver"
      [disabled]="true"
    ></ngx-uswds-radio-button-item>
  </ngx-uswds-radio-button>

  <h2>Radio Buttons — Tile</h2>
  <p>First item pre-selected; second item has a description; last item disabled.</p>

  <ngx-uswds-radio-button
    legend="Select one historical figure"
    name="historical-figures-tile"
    variant="tile"
    idPrefix="tile-demo"
  >
    <ngx-uswds-radio-button-item
      label="Sojourner Truth"
      value="sojourner-truth"
      [checkedByDefault]="true"
    ></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item
      label="Frederick Douglass"
      value="frederick-douglass"
      description="This is optional text that can be used to describe the label in more detail."
    ></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item
      label="Booker T. Washington"
      value="booker-t-washington"
    ></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item
      label="George Washington Carver"
      value="george-washington-carver"
      [disabled]="true"
    ></ngx-uswds-radio-button-item>
  </ngx-uswds-radio-button>

  <h2>Radio Buttons — No Default Selection</h2>
  <p>No item is pre-selected; user must make an explicit choice.</p>

  <ngx-uswds-radio-button legend="Choose a letter" name="letter" idPrefix="no-default">
    <ngx-uswds-radio-button-item label="A" value="a"></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item label="B" value="b"></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item label="C" value="c"></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item label="D" value="d"></ngx-uswds-radio-button-item>
  </ngx-uswds-radio-button>

  <h2>Radio Buttons — Last Item Pre-Selected</h2>
  <p>Confirms pre-selection works at any position in the list.</p>

  <ngx-uswds-radio-button legend="Preferred contact method" name="contact" idPrefix="last-selected">
    <ngx-uswds-radio-button-item label="Email" value="email"></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item label="Phone" value="phone"></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item label="Text message" value="text" [checkedByDefault]="true"></ngx-uswds-radio-button-item>
  </ngx-uswds-radio-button>

  <h2>Radio Buttons — All Disabled</h2>
  <p>Every item is disabled; reflects a read-only or locked state.</p>

  <ngx-uswds-radio-button legend="Survey response (locked)" name="survey-locked" idPrefix="all-disabled">
    <ngx-uswds-radio-button-item
      label="Strongly agree"
      value="strongly-agree"
      [disabled]="true"
    ></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item
      label="Agree"
      value="agree"
      [checkedByDefault]="true"
      [disabled]="true"
    ></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item
      label="Disagree"
      value="disagree"
      [disabled]="true"
    ></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item
      label="Strongly disagree"
      value="strongly-disagree"
      [disabled]="true"
    ></ngx-uswds-radio-button-item>
  </ngx-uswds-radio-button>

  <h2>Radio Buttons — Single Item</h2>
  <p>Edge case: a group containing only one radio button.</p>

  <ngx-uswds-radio-button legend="Confirm your selection" name="single-item" idPrefix="single">
    <ngx-uswds-radio-button-item label="I confirm" value="confirm"></ngx-uswds-radio-button-item>
  </ngx-uswds-radio-button>

  <h2>Radio Buttons — Tile, All Items with Descriptions</h2>
  <p>Every tile has a description providing additional context.</p>

  <ngx-uswds-radio-button
    legend="Choose a number"
    name="number"
    variant="tile"
    idPrefix="tile-all-desc"
  >
    <ngx-uswds-radio-button-item
      label="One"
      value="one"
      description="First number."
    ></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item
      label="Two"
      value="two"
      description="Second number."
      [checkedByDefault]="true"
    ></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item
      label="Three"
      value="three"
      description="Third number."
    ></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item
      label="Four"
      value="four"
      description="Fourth number."
      [disabled]="true"
    ></ngx-uswds-radio-button-item>
  </ngx-uswds-radio-button>

  <h2>Radio Buttons — Custom IDs</h2>
  <p>Each item uses an explicit <code>id</code> instead of the auto-generated one.</p>

  <ngx-uswds-radio-button legend="Assign a priority level" name="priority" idPrefix="custom-id-demo">
    <ngx-uswds-radio-button-item
      label="High"
      value="high"
      inputId="priority-high"
    ></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item
      label="Medium"
      value="medium"
      inputId="priority-medium"
      [checkedByDefault]="true"
    ></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item
      label="Low"
      value="low"
      inputId="priority-low"
    ></ngx-uswds-radio-button-item>
  </ngx-uswds-radio-button>

  <h2>Radio Buttons — Two Independent Groups</h2>
  <p>Two groups on the same page using auto-generated IDs. Selections are mutually exclusive within each group but independent between groups.</p>

  <ngx-uswds-radio-button legend="Preferred season" name="season">
    <ngx-uswds-radio-button-item label="Spring" value="spring" [checkedByDefault]="true"></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item label="Summer" value="summer"></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item label="Autumn" value="autumn"></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item label="Winter" value="winter"></ngx-uswds-radio-button-item>
  </ngx-uswds-radio-button>

  <ngx-uswds-radio-button legend="Preferred time of day" name="time-of-day" style="margin-top: 1.5rem; display: block;">
    <ngx-uswds-radio-button-item label="Morning" value="morning" [checkedByDefault]="true"></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item label="Afternoon" value="afternoon"></ngx-uswds-radio-button-item>
    <ngx-uswds-radio-button-item label="Evening" value="evening"></ngx-uswds-radio-button-item>
  </ngx-uswds-radio-button>
```

### Verify these things:

**Visually:**
- [ ] Radio button group renders with correct USWDS styling
- [ ] Default variant renders standard radio buttons with labels
- [ ] Tile variant renders larger tile-style radio buttons
- [ ] Only one item can be selected at a time within a group
- [ ] Items with description show description text below the label (tile variant)
- [ ] Items with disabled: true render as disabled and are not interactive
- [ ] Items with checkedByDefault: true render as selected on load

**Accessibility:**
- [ ] Radio buttons are grouped in a fieldset with a legend
- [ ] Each input id matches its corresponding label for attribute
- [ ] Disabled radio buttons are not keyboard-focusable
- [ ] All enabled radio buttons are keyboard-navigable with Tab and arrow keys