### PR TITLE
#31 USWDS Component Tag (Based On Main)

### DIFF
--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/tag-types.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/tag-types.ts
@@ -1,0 +1,1 @@
+export type TagVariant = 'default' | 'big';

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.html
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.html
@@ -1,0 +1,1 @@
+<p>uswds-tag works!</p>

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.html
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.html
@@ -1,1 +1,3 @@
-<p>uswds-tag works!</p>
+<span class="usa-tag" [ngClass]="tagVariantCSS()">
+  <ng-content></ng-content>
+</span>

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.spec.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.spec.ts
@@ -1,48 +1,81 @@
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UswdsTag } from './uswds-tag';
 
+// Test Host Component
+
+@Component({
+  standalone: true,
+  imports: [UswdsTag],
+  template: `<ngx-uswds-tag>INFO</ngx-uswds-tag>`,
+})
+class ContentHost {}
+
 describe('UswdsTag', () => {
-  let component: UswdsTag;
-  let fixture: ComponentFixture<UswdsTag>;
+  describe('Content projection', () => {
+    let fixture: ComponentFixture<ContentHost>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [UswdsTag],
-    }).compileComponents();
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [ContentHost],
+      }).compileComponents();
 
-    fixture = TestBed.createComponent(UswdsTag);
-    component = fixture.componentInstance;
-    await fixture.whenStable();
-  });
-
-  // Test initial tag creation
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-
-  it('should have variant of "default" when created', () => {
-    expect(component.variant()).toBe('default');
-  });
-
-  // Test the variants
-  it('should change to variant to "default" when provided', () => {
-    fixture.componentRef.setInput('variant', 'default');
-    fixture.detectChanges();
-    const el: HTMLElement = fixture.nativeElement.querySelector('.usa-tag');
-    expect(el.classList.length).toBe(1);
-  });
-
-  it('should change to variant to "big" when provided', () => {
-    fixture.componentRef.setInput('variant', 'big');
-    fixture.detectChanges();
-    const el: HTMLElement = fixture.nativeElement.querySelector('.usa-tag');
-    expect(el.classList.contains('usa-tag--big')).toBe(true);
-  });
-
-  it('should throw an error if invalid variant is provided', () => {
-    fixture.componentRef.setInput('variant', 'BADVARIANT');
-    expect(() => {
+      fixture = TestBed.createComponent(ContentHost);
       fixture.detectChanges();
-    }).toThrowError('Invalid variant selected, valid variants are: [default, big]');
+      await fixture.whenStable();
+    });
+
+    it('should render projected text content', () => {
+      const el: HTMLElement = fixture.nativeElement.querySelector('.usa-tag');
+      expect(el.textContent).toBe('INFO');
+    });
+  });
+
+  describe('Tag creation and variants', () => {
+    let component: UswdsTag;
+    let fixture: ComponentFixture<UswdsTag>;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [UswdsTag],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(UswdsTag);
+      component = fixture.componentInstance;
+      await fixture.whenStable();
+    });
+
+    // Test initial tag creation
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should have variant of "default" when created', () => {
+      expect(component.variant()).toBe('default');
+    });
+
+    // Test the variants
+    it('should change to variant to "default" when provided', () => {
+      fixture.componentRef.setInput('variant', 'default');
+      fixture.detectChanges();
+      const el: HTMLElement = fixture.nativeElement.querySelector('.usa-tag');
+      expect(el.classList.contains('usa-tag')).toBe(true);
+      expect(el.classList.length).toBe(1);
+    });
+
+    it('should change to variant to "big" when provided', () => {
+      fixture.componentRef.setInput('variant', 'big');
+      fixture.detectChanges();
+      const el: HTMLElement = fixture.nativeElement.querySelector('.usa-tag');
+      expect(el.classList.contains('usa-tag')).toBe(true);
+      expect(el.classList.contains('usa-tag--big')).toBe(true);
+    });
+
+    it('should throw an error if invalid variant is provided', () => {
+      fixture.componentRef.setInput('variant', 'BADVARIANT');
+      expect(() => {
+        fixture.detectChanges();
+      }).toThrowError('Invalid variant selected, valid variants are: [default, big]');
+    });
   });
 });

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.spec.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { UswdsTag } from './uswds-tag';
 
 describe('UswdsTag', () => {
@@ -16,7 +15,34 @@ describe('UswdsTag', () => {
     await fixture.whenStable();
   });
 
+  // Test initial tag creation
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should have variant of "default" when created', () => {
+    expect(component.variant()).toBe('default');
+  });
+
+  // Test the variants
+  it('should change to variant to "default" when provided', () => {
+    fixture.componentRef.setInput('variant', 'default');
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement.querySelector('.usa-tag');
+    expect(el.classList.length).toBe(1);
+  });
+
+  it('should change to variant to "big" when provided', () => {
+    fixture.componentRef.setInput('variant', 'big');
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement.querySelector('.usa-tag');
+    expect(el.classList.contains('usa-tag--big')).toBe(true);
+  });
+
+  it('should throw an error if invalid variant is provided', () => {
+    fixture.componentRef.setInput('variant', 'BADVARIANT');
+    expect(() => {
+      fixture.detectChanges();
+    }).toThrowError('Invalid variant selected, valid variants are: [default, big]');
   });
 });

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.spec.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UswdsTag } from './uswds-tag';
+
+describe('UswdsTag', () => {
+  let component: UswdsTag;
+  let fixture: ComponentFixture<UswdsTag>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UswdsTag],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UswdsTag);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'ngx-uswds-tag',
+  imports: [],
+  templateUrl: './uswds-tag.html',
+  styleUrl: './uswds-tag.scss',
+})
+
+/***
+ * @class
+ * @description
+ * An Angular standalone component that renders a U.S. Web Design System (USWDS) tag.
+ * Tags help draws users' attention to new content, filter results, or show the number of new or unread items for a container.
+ * @selector ngx-uswds-tag
+ *
+ * @example
+ *
+ * @input
+ */
+export class UswdsTag {}

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.ts
@@ -44,9 +44,3 @@ export class UswdsTag {
     }
   }
 }
-
-/*
-TO DO:
-- keep cross checking from uswds-banner
-- check if error comes up
-*/

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.ts
@@ -1,21 +1,52 @@
-import { Component } from '@angular/core';
-
-@Component({
-  selector: 'ngx-uswds-tag',
-  imports: [],
-  templateUrl: './uswds-tag.html',
-  styleUrl: './uswds-tag.scss',
-})
+import { Component, input } from '@angular/core';
+import { NgClass } from '@angular/common';
+import { TagVariant } from './tag-types';
 
 /***
- * @class
+ * @class UswdsTag
  * @description
  * An Angular standalone component that renders a U.S. Web Design System (USWDS) tag.
  * Tags help draws users' attention to new content, filter results, or show the number of new or unread items for a container.
+ * They support a big visual variant.
+ *
  * @selector ngx-uswds-tag
  *
  * @example
+ * <!-- Using the default tag -->
+ * <ngx-uswds-tag>INFO</ngx-uswds-tag>
+ * <ngx-uswds-tag variant='default'>INFO</ngx-uswds-tag>
  *
- * @input
+ * @example
+ * <!-- Using the big tag -->
+ * <ngx-uswds-tag variant='big'>BIG</ngx-uswds-tag>
+ *
+ * @input {TagVariant} [variant='default'] - Sets the variant style of the tag.
+ *    It's 'default' variant automatically. 'big' sets the tag to big variant.
  */
-export class UswdsTag {}
+@Component({
+  selector: 'ngx-uswds-tag',
+  imports: [NgClass],
+  templateUrl: './uswds-tag.html',
+  styleUrl: './uswds-tag.scss',
+})
+export class UswdsTag {
+  variant = input<TagVariant>('default');
+
+  // Tag variant selection function
+  tagVariantCSS(): string {
+    switch (this.variant()) {
+      case 'default':
+        return '';
+      case 'big':
+        return 'usa-tag--big';
+      default:
+        throw new Error('Invalid variant selected, valid variants are: [default, big]');
+    }
+  }
+}
+
+/*
+TO DO:
+- keep cross checking from uswds-banner
+- check if error comes up
+*/

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-tag/uswds-tag.ts
@@ -30,6 +30,7 @@ import { TagVariant } from './tag-types';
   styleUrl: './uswds-tag.scss',
 })
 export class UswdsTag {
+  // v8 ignore next
   variant = input<TagVariant>('default');
 
   // Tag variant selection function

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/public-api.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/public-api.ts
@@ -24,3 +24,6 @@ export type { BreadcrumbVariant } from './components/uswds-breadcrumb/uswds-brea
 export * from './components/uswds-checkbox/uswds-checkbox';
 export * from './components/uswds-checkbox-item/uswds-checkbox-item';
 export type { CheckboxVariant } from './components/uswds-checkbox/checkbox-types';
+
+// Tag Component
+export * from "./components/uswds-tag/uswds-tag";


### PR DESCRIPTION
## Description
This pull request aims to tackle issue #31 by creating a USWDS Tag component for Angular, following the the U.S. Web Design System (USWDS) specifications [https://designsystem.digital.gov/components/tag/](https://designsystem.digital.gov/components/tag/).

## Code Changes
New files:
* ```ngx-uswds-lib/src/components/uswds-tag/uswds-tag.ts```: Contains the Tag component logic including guidance on how to use the component, handling input, and updating the CSS according to the variant.
* ```ngx-uswds-lib/src/components/uswds-tag/uswds-tag.html```: Defines the DOM for the Tag component, replicating it close to the USWDS version.
* ```ngx-uswds-lib/src/components/uswds-tag/uswds-tag.scss```: Reserved for component-specific styles. This file is currently empty.
* ```ngx-uswds-lib/src/components/uswds-tag/tag-types.ts```: Defines a custom type named ```TagVariant``` to ensure only valid variants can be assigned.
* ```ngx-uswds-lib/src/components/uswds-tag/uswds-tag.spec.ts```: Contains unit tests for the Tag component, including testing its variants.

Modified files:
* ```ngx-uswds-lib/src/public-api.ts```: Added Tag component to be exported

## Testing
Unit Testing:
* Tests cover:
    * 'default' variant is assigned implicitly when no variant is specified
    *  When specified, the correct 'big' or 'default' variant applies to the Tag component using the prop called `variant`
    *  Variants not defined by USWDS result in an error

1. Run ```ng test --coverage```  in ngx-uswds-workspace
2. Confirm that every unit test for the Tag component passes and has full coverage

Manual Testing:
1. Start the Demo app and import the Tag component in `app.ts`:
```ts
import { UswdsTag } from 'ngx-uswds-lib';
```
3. Paste the following examples in ```app.html```:

```html
<ngx-uswds-tag>INFO</ngx-uswds-tag>
<ngx-uswds-tag variant='default'>INFO</ngx-uswds-tag>
<ngx-uswds-tag variant='big'>BIG</ngx-uswds-tag>
```
4. Confirm that visually the first two default variant Tags are the same size and that the third big variant Tag is larger
5. Confirm that when you zoom in to at least 200%, the tag is still fully visible