### PR TITLE
#36 USWDS Component Icon (Based On Main)

### DIFF
--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/icon-types.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/icon-types.ts
@@ -1,0 +1,1 @@
+export type IconSize = 3 | 4 | 5 | 6 | 7 | 8 | 9;

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.html
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.html
@@ -1,10 +1,13 @@
-<svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
-  <use href="/assets/img/sprite.svg#accessibility_new"></use>
+<svg
+  class="usa-icon"
+  role="img"
+  [ngClass]="iconSizeCss()"
+  [attr.aria-hidden]="ariaHidden()"
+  [attr.focusable]="focusable()"
+  [attr.aria-labelledby]="ariaLabelledBy()"
+>
+  @if (title()) {
+    <title [id]="computedTitleId()">{{ title() }}</title>
+  }
+  <use [attr.href]="iconPath()"></use>
 </svg>
-
-<a href="https://twitter.com/uswds">
-  <svg class="usa-icon" aria-labelledby="twitter-title" role="img">
-    <title id="twitter-title">USWDS' Twitter account</title>
-    <use href="/assets/img/sprite.svg#twitter"></use>
-  </svg>
-</a>

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.html
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.html
@@ -1,0 +1,10 @@
+<svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+  <use href="/assets/img/sprite.svg#accessibility_new"></use>
+</svg>
+
+<a href="https://twitter.com/uswds">
+  <svg class="usa-icon" aria-labelledby="twitter-title" role="img">
+    <title id="twitter-title">USWDS' Twitter account</title>
+    <use href="/assets/img/sprite.svg#twitter"></use>
+  </svg>
+</a>

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.spec.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.spec.ts
@@ -72,6 +72,14 @@ describe('UswdsIcon', () => {
       const use = el.querySelector('use');
       expect(use?.getAttribute('href')).toBe('/assets/img/sprite.svg#home');
     });
+
+    it('should use the custom assets path', () => {
+      fixture.componentRef.setInput('assetsPath', '/custom/path');
+      fixture.detectChanges();
+      expect(component.iconPath()).toBe('/custom/path/sprite.svg#home');
+      const use = el.querySelector('use');
+      expect(use?.getAttribute('href')).toBe('/custom/path/sprite.svg#home');
+    });
   });
 
   describe('Sizes', () => {

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.spec.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.spec.ts
@@ -70,7 +70,7 @@ describe('UswdsIcon', () => {
     it('should use the correct icon path', () => {
       expect(component.iconPath()).toBe('/assets/img/sprite.svg#home');
       const use = el.querySelector('use');
-      expect(use?.getAttribute('href')).toBe('/assets/img/sprite.svg#home');
+      expect(use!.getAttribute('href')).toBe('/assets/img/sprite.svg#home');
     });
 
     it('should use the custom assets path', () => {
@@ -78,7 +78,7 @@ describe('UswdsIcon', () => {
       fixture.detectChanges();
       expect(component.iconPath()).toBe('/custom/path/sprite.svg#home');
       const use = el.querySelector('use');
-      expect(use?.getAttribute('href')).toBe('/custom/path/sprite.svg#home');
+      expect(use!.getAttribute('href')).toBe('/custom/path/sprite.svg#home');
     });
   });
 
@@ -105,49 +105,49 @@ describe('UswdsIcon', () => {
       fixture.componentRef.setInput('size', 3);
       fixture.detectChanges();
       const svg = el.querySelector('svg');
-      expect(svg?.classList.contains('usa-icon--size-3')).toBeTruthy();
+      expect(svg!.classList.contains('usa-icon--size-3')).toBeTruthy();
     });
 
     it('should change size to 4', () => {
       fixture.componentRef.setInput('size', 4);
       fixture.detectChanges();
       const svg = el.querySelector('svg');
-      expect(svg?.classList.contains('usa-icon--size-4')).toBeTruthy();
+      expect(svg!.classList.contains('usa-icon--size-4')).toBeTruthy();
     });
 
     it('should change size to 5', () => {
       fixture.componentRef.setInput('size', 5);
       fixture.detectChanges();
       const svg = el.querySelector('svg');
-      expect(svg?.classList.contains('usa-icon--size-5')).toBeTruthy();
+      expect(svg!.classList.contains('usa-icon--size-5')).toBeTruthy();
     });
 
     it('should change size to 6', () => {
       fixture.componentRef.setInput('size', 6);
       fixture.detectChanges();
       const svg = el.querySelector('svg');
-      expect(svg?.classList.contains('usa-icon--size-6')).toBeTruthy();
+      expect(svg!.classList.contains('usa-icon--size-6')).toBeTruthy();
     });
 
     it('should change size to 7', () => {
       fixture.componentRef.setInput('size', 7);
       fixture.detectChanges();
       const svg = el.querySelector('svg');
-      expect(svg?.classList.contains('usa-icon--size-7')).toBeTruthy();
+      expect(svg!.classList.contains('usa-icon--size-7')).toBeTruthy();
     });
 
     it('should change size to 8', () => {
       fixture.componentRef.setInput('size', 8);
       fixture.detectChanges();
       const svg = el.querySelector('svg');
-      expect(svg?.classList.contains('usa-icon--size-8')).toBeTruthy();
+      expect(svg!.classList.contains('usa-icon--size-8')).toBeTruthy();
     });
 
     it('should change size to 9', () => {
       fixture.componentRef.setInput('size', 9);
       fixture.detectChanges();
       const svg = el.querySelector('svg');
-      expect(svg?.classList.contains('usa-icon--size-9')).toBeTruthy();
+      expect(svg!.classList.contains('usa-icon--size-9')).toBeTruthy();
     });
 
     it('should throw an error if invalid size is provided', () => {
@@ -169,28 +169,29 @@ describe('UswdsIcon', () => {
 
       fixture = TestBed.createComponent(DecorativeHost);
       el = fixture.nativeElement;
+      fixture.detectChanges();
 
       await fixture.whenStable();
     });
 
     it('should have aria-hidden="true"', () => {
       const svg = el.querySelector('svg');
-      expect(svg?.getAttribute('aria-hidden'))?.toBe('true');
+      expect(svg!.getAttribute('aria-hidden')).toBe('true');
     });
 
     it('should have role="img"', () => {
       const svg = el.querySelector('svg');
-      expect(svg?.getAttribute('role'))?.toBe('img');
+      expect(svg!.getAttribute('role')).toBe('img');
     });
 
     it('should have focusable="false"', () => {
       const svg = el.querySelector('svg');
-      expect(svg?.getAttribute('focusable'))?.toBe('false');
+      expect(svg!.getAttribute('focusable')).toBe('false');
     });
 
     it('should render accompanied text', () => {
       const a = el.querySelector('a');
-      expect(a?.textContent.trim()).toBe("USWDS' Twitter account");
+      expect(a!.textContent.trim()).toBe("USWDS' Twitter account");
     });
   });
 
@@ -205,19 +206,20 @@ describe('UswdsIcon', () => {
 
       fixture = TestBed.createComponent(DescriptiveHost);
       el = fixture.nativeElement;
+      fixture.detectChanges();
 
       await fixture.whenStable();
     });
 
     it('should have role="img"', () => {
       const svg = el.querySelector('svg');
-      expect(svg?.getAttribute('role'))?.toBe('img');
+      expect(svg!.getAttribute('role')).toBe('img');
     });
 
     it('should not have any decorative icon markup', () => {
       const svg = el.querySelector('svg');
-      expect(svg?.getAttribute('aria-hidden'))?.toBeNull();
-      expect(svg?.getAttribute('focusable'))?.toBeNull();
+      expect(svg!.getAttribute('aria-hidden')).toBeNull();
+      expect(svg!.getAttribute('focusable')).toBeNull();
     });
 
     it('should have a title element', () => {
@@ -225,19 +227,19 @@ describe('UswdsIcon', () => {
     });
 
     it('should generate a unique ID for title', () => {
-      const id = el.querySelector('title')?.getAttribute('id');
+      const id = el.querySelector('title')!.getAttribute('id');
       expect(id).toMatch(/^[a-z_]+-\d+-title$/);
     });
 
     it('should link the title`s id to the svg`s aria-labelledby', () => {
-      const titleId = el.querySelector('title')?.getAttribute('id');
-      const svgAriaLabel = el.querySelector('svg')?.getAttribute('aria-labelledby');
+      const titleId = el.querySelector('title')!.getAttribute('id');
+      const svgAriaLabel = el.querySelector('svg')!.getAttribute('aria-labelledby');
       expect(titleId).toEqual(svgAriaLabel);
     });
 
     it('should render the descriptive text', () => {
       const title = el.querySelector('title');
-      expect(title?.textContent).toEqual("USWDS' Twitter account");
+      expect(title!.textContent).toEqual("USWDS' Twitter account");
     });
 
     it('should error if the descriptive text is empty', () => {
@@ -246,7 +248,7 @@ describe('UswdsIcon', () => {
       f.componentRef.setInput('title', '');
       expect(() => {
         f.detectChanges();
-      }).toThrowError('Propery "title" cannot be an empty string');
+      }).toThrowError('Property "title" cannot be an empty string');
     });
   });
 });

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.spec.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.spec.ts
@@ -1,22 +1,235 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { Component } from '@angular/core';
 import { UswdsIcon } from './uswds-icon';
 
+// Test Host Components
+
+@Component({
+  standalone: true,
+  imports: [UswdsIcon],
+  template: `
+    <a href="/uswds">
+      <ngx-uswds-icon name="twitter"></ngx-uswds-icon>
+      USWDS' Twitter account
+    </a>
+  `,
+})
+class DecorativeHost {}
+
+@Component({
+  standalone: true,
+  imports: [UswdsIcon],
+  template: `
+    <a href="/uswds">
+      <ngx-uswds-icon name="twitter" title="USWDS' Twitter account"></ngx-uswds-icon>
+    </a>
+  `,
+})
+class AccessibleHost {}
+
+// Test Suite
+
 describe('UswdsIcon', () => {
-  let component: UswdsIcon;
-  let fixture: ComponentFixture<UswdsIcon>;
+  describe('Creation', () => {
+    let component: UswdsIcon;
+    let fixture: ComponentFixture<UswdsIcon>;
+    let el: HTMLElement;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [UswdsIcon],
-    }).compileComponents();
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [UswdsIcon],
+      }).compileComponents();
 
-    fixture = TestBed.createComponent(UswdsIcon);
-    component = fixture.componentInstance;
-    await fixture.whenStable();
+      fixture = TestBed.createComponent(UswdsIcon);
+      component = fixture.componentInstance;
+      el = fixture.nativeElement;
+
+      // Provide required prop
+      fixture.componentRef.setInput('name', 'home');
+      fixture.detectChanges();
+
+      await fixture.whenStable();
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should use default assets path', () => {
+      expect(component.assetsPath()).toBe('/assets/img');
+    });
+
+    it('should render a svg with usa-icon class', () => {
+      expect(el.querySelector('svg.usa-icon')).toBeTruthy();
+    });
+
+    it('should render an use element', () => {
+      expect(el.querySelector('use')).toBeTruthy();
+    });
+
+    it('should use the correct icon path', () => {
+      expect(component.iconPath()).toBe('/assets/img/sprite.svg#home');
+      const use = el.querySelector('use');
+      expect(use?.getAttribute('href')).toBe('/assets/img/sprite.svg#home');
+    });
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('Sizes', () => {
+    let fixture: ComponentFixture<UswdsIcon>;
+    let el: HTMLElement;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [UswdsIcon],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(UswdsIcon);
+      el = fixture.nativeElement;
+
+      // Provide required prop
+      fixture.componentRef.setInput('name', 'home');
+      fixture.detectChanges();
+
+      await fixture.whenStable();
+    });
+
+    it('should change size to 3', () => {
+      fixture.componentRef.setInput('size', 3);
+      fixture.detectChanges();
+      const svg = el.querySelector('svg');
+      expect(svg?.classList.contains('usa-icon--size-3')).toBeTruthy();
+    });
+
+    it('should change size to 4', () => {
+      fixture.componentRef.setInput('size', 4);
+      fixture.detectChanges();
+      const svg = el.querySelector('svg');
+      expect(svg?.classList.contains('usa-icon--size-4')).toBeTruthy();
+    });
+
+    it('should change size to 5', () => {
+      fixture.componentRef.setInput('size', 5);
+      fixture.detectChanges();
+      const svg = el.querySelector('svg');
+      expect(svg?.classList.contains('usa-icon--size-5')).toBeTruthy();
+    });
+
+    it('should change size to 6', () => {
+      fixture.componentRef.setInput('size', 6);
+      fixture.detectChanges();
+      const svg = el.querySelector('svg');
+      expect(svg?.classList.contains('usa-icon--size-6')).toBeTruthy();
+    });
+
+    it('should change size to 7', () => {
+      fixture.componentRef.setInput('size', 7);
+      fixture.detectChanges();
+      const svg = el.querySelector('svg');
+      expect(svg?.classList.contains('usa-icon--size-7')).toBeTruthy();
+    });
+
+    it('should change size to 8', () => {
+      fixture.componentRef.setInput('size', 8);
+      fixture.detectChanges();
+      const svg = el.querySelector('svg');
+      expect(svg?.classList.contains('usa-icon--size-8')).toBeTruthy();
+    });
+
+    it('should change size to 9', () => {
+      fixture.componentRef.setInput('size', 9);
+      fixture.detectChanges();
+      const svg = el.querySelector('svg');
+      expect(svg?.classList.contains('usa-icon--size-9')).toBeTruthy();
+    });
+
+    it('should throw an error if invalid size is provided', () => {
+      fixture.componentRef.setInput('size', 10);
+      expect(() => {
+        fixture.detectChanges();
+      }).toThrowError('Invalid size selected, valid options are 3-9');
+    });
+  });
+
+  describe('Decorative icon', () => {
+    let fixture: ComponentFixture<DecorativeHost>;
+    let el: HTMLElement;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [DecorativeHost],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(DecorativeHost);
+      el = fixture.nativeElement;
+
+      await fixture.whenStable();
+    });
+
+    it('should have aria-hidden="true"', () => {
+      const svg = el.querySelector('svg');
+      expect(svg?.getAttribute('aria-hidden'))?.toBe('true');
+    });
+
+    it('should have role="img"', () => {
+      const svg = el.querySelector('svg');
+      expect(svg?.getAttribute('role'))?.toBe('img');
+    });
+
+    it('should have focusable="false"', () => {
+      const svg = el.querySelector('svg');
+      expect(svg?.getAttribute('focusable'))?.toBe('false');
+    });
+
+    it('should render accompanied text', () => {
+      const a = el.querySelector('a');
+      expect(a?.textContent.trim()).toBe("USWDS' Twitter account");
+    });
+  });
+
+  describe('Accessible icon', () => {
+    let fixture: ComponentFixture<AccessibleHost>;
+    let el: HTMLElement;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [AccessibleHost],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(AccessibleHost);
+      el = fixture.nativeElement;
+
+      await fixture.whenStable();
+    });
+
+    it('should have role="img"', () => {
+      const svg = el.querySelector('svg');
+      expect(svg?.getAttribute('role'))?.toBe('img');
+    });
+
+    it('should not have any decorative icon markup', () => {
+      const svg = el.querySelector('svg');
+      expect(svg?.getAttribute('aria-hidden'))?.toBeNull();
+      expect(svg?.getAttribute('focusable'))?.toBeNull();
+    });
+
+    it('should have a title element', () => {
+      expect(el.querySelector('title')).toBeTruthy();
+    });
+
+    it('should generate a unique ID for title', () => {
+      const id = el.querySelector('title')?.getAttribute('id');
+      expect(id).toMatch(/^[a-z_]+-\d+-title$/);
+    });
+
+    it('should link the title`s id to the svg`s aria-labelledby', () => {
+      const titleId = el.querySelector('title')?.getAttribute('id');
+      const svgAriaLabel = el.querySelector('svg')?.getAttribute('aria-labelledby');
+      expect(titleId).toEqual(svgAriaLabel);
+    });
+
+    it('should render the text alternative', () => {
+      const title = el.querySelector('title');
+      expect(title?.textContent).toEqual("USWDS' Twitter account");
+    });
   });
 });

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.spec.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UswdsIcon } from './uswds-icon';
+
+describe('UswdsIcon', () => {
+  let component: UswdsIcon;
+  let fixture: ComponentFixture<UswdsIcon>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UswdsIcon],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UswdsIcon);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.spec.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.spec.ts
@@ -25,7 +25,7 @@ class DecorativeHost {}
     </a>
   `,
 })
-class AccessibleHost {}
+class DescriptiveHost {}
 
 // Test Suite
 
@@ -186,16 +186,16 @@ describe('UswdsIcon', () => {
     });
   });
 
-  describe('Accessible icon', () => {
-    let fixture: ComponentFixture<AccessibleHost>;
+  describe('Descriptive icon', () => {
+    let fixture: ComponentFixture<DescriptiveHost>;
     let el: HTMLElement;
 
     beforeEach(async () => {
       await TestBed.configureTestingModule({
-        imports: [AccessibleHost],
+        imports: [DescriptiveHost],
       }).compileComponents();
 
-      fixture = TestBed.createComponent(AccessibleHost);
+      fixture = TestBed.createComponent(DescriptiveHost);
       el = fixture.nativeElement;
 
       await fixture.whenStable();
@@ -227,9 +227,18 @@ describe('UswdsIcon', () => {
       expect(titleId).toEqual(svgAriaLabel);
     });
 
-    it('should render the text alternative', () => {
+    it('should render the descriptive text', () => {
       const title = el.querySelector('title');
       expect(title?.textContent).toEqual("USWDS' Twitter account");
+    });
+
+    it('should error if the descriptive text is empty', () => {
+      const f = TestBed.createComponent(UswdsIcon);
+      f.componentRef.setInput('name', 'home');
+      f.componentRef.setInput('title', '');
+      expect(() => {
+        f.detectChanges();
+      }).toThrowError('Propery "title" cannot be an empty string');
     });
   });
 });

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.ts
@@ -1,4 +1,4 @@
-import { Component, input, computed, signal, AfterContentInit } from '@angular/core';
+import { Component, input, computed, signal, OnInit, AfterContentInit } from '@angular/core';
 import { NgClass } from '@angular/common';
 import { IconSize } from './icon-types';
 
@@ -43,7 +43,7 @@ import { IconSize } from './icon-types';
   templateUrl: './uswds-icon.html',
   styleUrl: './uswds-icon.scss',
 })
-export class UswdsIcon implements AfterContentInit {
+export class UswdsIcon implements OnInit, AfterContentInit {
   // v8 ignore next
   name = input.required<string>();
   // v8 ignore next
@@ -59,7 +59,7 @@ export class UswdsIcon implements AfterContentInit {
 
   ngOnInit(): void {
     if (this.title() === '') {
-      throw new Error('Propery "title" cannot be an empty string');
+      throw new Error('Property "title" cannot be an empty string');
     }
   }
 

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.ts
@@ -1,4 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, input, computed, AfterContentInit } from '@angular/core';
+import { NgClass } from '@angular/common';
+import { IconSize } from './icon-types';
 
 /**
  * @class UswdsIcon
@@ -9,21 +11,93 @@ import { Component } from '@angular/core';
  * @selector ngx-uswds-icon
  *
  * @example
- * <!-- Using the default tag -->
- * <ngx-uswds-tag>INFO</ngx-uswds-tag>
- * <ngx-uswds-tag variant='default'>INFO</ngx-uswds-tag>
+ * <!-- Using an icon -->
  *
  * @example
- * <!-- Using the big tag -->
- * <ngx-uswds-tag variant='big'>BIG</ngx-uswds-tag>
+ * <!-- Using an accessible icon -->
  *
- * @input {TagVariant} [variant='default'] - Sets the variant style of the tag.
+ * @input {string} name - Sets the variant style of the tag.
+ *    It's 'default' variant automatically. 'big' sets the tag to big variant.
+ *
+ * @input {string} size - Sets the variant style of the tag.
  *    It's 'default' variant automatically. 'big' sets the tag to big variant.
  */
 @Component({
   selector: 'ngx-uswds-icon',
-  imports: [],
+  imports: [NgClass],
   templateUrl: './uswds-icon.html',
   styleUrl: './uswds-icon.scss',
 })
-export class UswdsIcon {}
+export class UswdsIcon implements AfterContentInit {
+  name = input.required<string>();
+  size = input<IconSize>();
+  title = input<string>();
+  assetsPath = input<string>('/assets/img');
+
+  private static instanceCounter = 0;
+  private titleId = '';
+
+  ngAfterContentInit(): void {
+    this.titleId = this.generateUniqueTitleId();
+  }
+
+  private generateUniqueTitleId(): string {
+    UswdsIcon.instanceCounter++;
+    return `${this.name()}-${UswdsIcon.instanceCounter}-title`;
+  }
+
+  computedTitleId = computed(() => this.computedTitleIdFn());
+  computedTitleIdFn = () => {
+    const title = this.title();
+    if (title) return this.titleId;
+    return null;
+  };
+
+  ariaHidden = computed(() => this.ariaHiddenFn());
+  ariaHiddenFn = () => {
+    const title = this.title();
+    if (title) return null;
+    return true;
+  };
+
+  focusable = computed(() => this.focusableFn());
+  focusableFn = () => {
+    const title = this.title();
+    if (title) return null;
+    return false;
+  };
+
+  ariaLabelledBy = computed(() => this.ariaLabelledByFn());
+  ariaLabelledByFn = () => {
+    const title = this.title();
+    if (title) return this.titleId;
+    return null;
+  };
+
+  // Icon size selection function
+  iconSizeCss = computed(() => this.iconSizeCssFn());
+  iconSizeCssFn = () => {
+    switch (this.size()) {
+      case undefined:
+        return '';
+      case 3:
+        return 'usa-icon--size-3';
+      case 4:
+        return 'usa-icon--size-4';
+      case 5:
+        return 'usa-icon--size-5';
+      case 6:
+        return 'usa-icon--size-6';
+      case 7:
+        return 'usa-icon--size-7';
+      case 8:
+        return 'usa-icon--size-8';
+      case 9:
+        return 'usa-icon--size-9';
+      default:
+        throw new Error('Invalid size selected, valid options are 3-9');
+    }
+  };
+
+  iconPath = computed(() => `${this.assetsPath()}/sprite.svg#${this.name()}`);
+}

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+
+/**
+ * @class UswdsIcon
+ * @description
+ * An Angular standalone component that renders a U.S. Web Design System (USWDS) icon.
+ * Icons...
+ *
+ * @selector ngx-uswds-icon
+ *
+ * @example
+ * <!-- Using the default tag -->
+ * <ngx-uswds-tag>INFO</ngx-uswds-tag>
+ * <ngx-uswds-tag variant='default'>INFO</ngx-uswds-tag>
+ *
+ * @example
+ * <!-- Using the big tag -->
+ * <ngx-uswds-tag variant='big'>BIG</ngx-uswds-tag>
+ *
+ * @input {TagVariant} [variant='default'] - Sets the variant style of the tag.
+ *    It's 'default' variant automatically. 'big' sets the tag to big variant.
+ */
+@Component({
+  selector: 'ngx-uswds-icon',
+  imports: [],
+  templateUrl: './uswds-icon.html',
+  styleUrl: './uswds-icon.scss',
+})
+export class UswdsIcon {}

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.ts
@@ -1,4 +1,4 @@
-import { Component, input, computed, AfterContentInit } from '@angular/core';
+import { Component, input, computed, signal, AfterContentInit } from '@angular/core';
 import { NgClass } from '@angular/common';
 import { IconSize } from './icon-types';
 
@@ -6,21 +6,36 @@ import { IconSize } from './icon-types';
  * @class UswdsIcon
  * @description
  * An Angular standalone component that renders a U.S. Web Design System (USWDS) icon.
- * Icons...
+ * Icons are simple symbols that help communicate meaning, actions, status or feedback.
+ * They should be combined with text to improve clarity or be within another interactive component.
+ *
+ * Note: Change the icon's color by applying one of the USWDS text color classes on its direct parent.
+ * The title's ID is auto-generated to avoid ID collisions between multiple descriptive icons on the same page.
  *
  * @selector ngx-uswds-icon
  *
  * @example
- * <!-- Using an icon -->
+ * <!-- Using a decorative icon -->
+ * <a href="/uswds">
+ *  <ngx-uswds-icon name="twitter" [size]="3"></ngx-uswds-icon>
+ *  USWDS' Twitter account
+ * </a>
  *
  * @example
- * <!-- Using an accessible icon -->
+ * <!-- Using a descriptive icon -->
+ * <a href="/uswds">
+ *  <ngx-uswds-icon name="twitter" title="USWDS' Twitter account"></ngx-uswds-icon>
+ * </a>
  *
- * @input {string} name - Sets the variant style of the tag.
- *    It's 'default' variant automatically. 'big' sets the tag to big variant.
+ * @input {string} name - Sets the visual icon. Refer to USWDS's list of icons to help choose an icon. Required.
  *
- * @input {string} size - Sets the variant style of the tag.
- *    It's 'default' variant automatically. 'big' sets the tag to big variant.
+ * @input {IconSize} size - The size of the icon in n x n units. Accepts 3-9. Optional.
+ *
+ * @input {string} title - The descriptive text rendered in the icon's <title>. Should be provided when the icon has
+ *   no accompanying text to make the icon perceivable to screen readers. Optional.
+ *
+ * @input {string} [assetsPath='/assets/img'] - Base path to the icon image assets.
+ *   Useful when assets are hosted in a different location. Optional.
  */
 @Component({
   selector: 'ngx-uswds-icon',
@@ -37,12 +52,19 @@ export class UswdsIcon implements AfterContentInit {
   title = input<string>();
   // v8 ignore next
   assetsPath = input<string>('/assets/img');
+  // v8 ignore next
+  titleId = signal<string>('');
 
   private static instanceCounter = 0;
-  private titleId = '';
+
+  ngOnInit(): void {
+    if (this.title() === '') {
+      throw new Error('Propery "title" cannot be an empty string');
+    }
+  }
 
   ngAfterContentInit(): void {
-    this.titleId = this.generateUniqueTitleId();
+    this.titleId.set(this.generateUniqueTitleId());
   }
 
   private generateUniqueTitleId(): string {
@@ -51,7 +73,7 @@ export class UswdsIcon implements AfterContentInit {
   }
 
   // v8 ignore next
-  computedTitleId = computed(() => this.titleId);
+  computedTitleId = computed(() => this.titleId());
 
   // v8 ignore next
   ariaHidden = computed(() => this.ariaHiddenFn());
@@ -73,7 +95,7 @@ export class UswdsIcon implements AfterContentInit {
   ariaLabelledBy = computed(() => this.ariaLabelledByFn());
   ariaLabelledByFn = () => {
     const title = this.title();
-    if (title) return this.titleId;
+    if (title) return this.titleId();
     return null;
   };
 

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/components/uswds-icon/uswds-icon.ts
@@ -29,9 +29,13 @@ import { IconSize } from './icon-types';
   styleUrl: './uswds-icon.scss',
 })
 export class UswdsIcon implements AfterContentInit {
+  // v8 ignore next
   name = input.required<string>();
+  // v8 ignore next
   size = input<IconSize>();
+  // v8 ignore next
   title = input<string>();
+  // v8 ignore next
   assetsPath = input<string>('/assets/img');
 
   private static instanceCounter = 0;
@@ -46,13 +50,10 @@ export class UswdsIcon implements AfterContentInit {
     return `${this.name()}-${UswdsIcon.instanceCounter}-title`;
   }
 
-  computedTitleId = computed(() => this.computedTitleIdFn());
-  computedTitleIdFn = () => {
-    const title = this.title();
-    if (title) return this.titleId;
-    return null;
-  };
+  // v8 ignore next
+  computedTitleId = computed(() => this.titleId);
 
+  // v8 ignore next
   ariaHidden = computed(() => this.ariaHiddenFn());
   ariaHiddenFn = () => {
     const title = this.title();
@@ -60,6 +61,7 @@ export class UswdsIcon implements AfterContentInit {
     return true;
   };
 
+  // v8 ignore next
   focusable = computed(() => this.focusableFn());
   focusableFn = () => {
     const title = this.title();
@@ -67,6 +69,7 @@ export class UswdsIcon implements AfterContentInit {
     return false;
   };
 
+  // v8 ignore next
   ariaLabelledBy = computed(() => this.ariaLabelledByFn());
   ariaLabelledByFn = () => {
     const title = this.title();
@@ -75,6 +78,7 @@ export class UswdsIcon implements AfterContentInit {
   };
 
   // Icon size selection function
+  // v8 ignore next
   iconSizeCss = computed(() => this.iconSizeCssFn());
   iconSizeCssFn = () => {
     switch (this.size()) {
@@ -99,5 +103,6 @@ export class UswdsIcon implements AfterContentInit {
     }
   };
 
+  // v8 ignore next
   iconPath = computed(() => `${this.assetsPath()}/sprite.svg#${this.name()}`);
 }

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/public-api.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/public-api.ts
@@ -33,4 +33,4 @@ export * from './components/uswds-text-input/uswds-text-input';
 
 // Icon Component
 export * from "./components/uswds-icon/uswds-icon";
-export type { IconSize } from "./components/uswds-icon/icon-types.ts";
+export type { IconSize } from "./components/uswds-icon/icon-types";

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/public-api.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/public-api.ts
@@ -27,3 +27,6 @@ export type { CheckboxVariant } from './components/uswds-checkbox/checkbox-types
 
 // Tag Component
 export * from "./components/uswds-tag/uswds-tag";
+
+// Icon Component
+export * from "./components/uswds-icon/uswds-icon";

--- a/ngx-uswds-workspace/projects/ngx-uswds-lib/src/public-api.ts
+++ b/ngx-uswds-workspace/projects/ngx-uswds-lib/src/public-api.ts
@@ -30,3 +30,4 @@ export * from "./components/uswds-tag/uswds-tag";
 
 // Icon Component
 export * from "./components/uswds-icon/uswds-icon";
+export type { IconSize } from "./components/uswds-icon/icon-types.ts";


### PR DESCRIPTION
## Description
This pull request aims to tackle issue #36 by creating a USWDS Icon component for Angular, following the the U.S. Web Design System (USWDS) specifications [https://designsystem.digital.gov/components/icon/](https://designsystem.digital.gov/components/icon/). Icons are simple symbols can be decorative or have descriptive text if needed.

## Code Changes
New files:
* `ngx-uswds-lib/src/components/uswds-icon/uswds-icon.ts`: Contains the Icon component logic including guidance on how to use the component, handling input, and generating an id for `<title>`.
* `ngx-uswds-lib/src/components/uswds-icon/uswds-icon.html`: Template that always renders a `<svg>` and `<use>` and optionally renders a `<title>` if descriptive text (`title`) is provided.
* `ngx-uswds-lib/src/components/uswds-icon/uswds-icon.scss`: Reserved for Icon-specific styles. This file is currently empty.
* `ngx-uswds-lib/src/components/uswds-icon/icon-types.ts`: Defines a custom type named `IconSize` to ensure only valid sizes can be assigned.
* `ngx-uswds-lib/src/components/uswds-icon/uswds-icon.spec.ts`: Contains unit tests.

Modified files:
* `ngx-uswds-lib/src/public-api.ts`: Added Icon component to be exported.

## Testing
Unit Testing:
* Tests cover:
    * DOM rendering of a decorative and descriptive icon
    *  Generating icon image paths
    *  Setting icon's size
    * Accessibility attributes (aria-labelledby, aria-hidden, focusable, role)

1. Run `ng test --coverage`  in ngx-uswds-workspace
2. Confirm that every unit test for the Icon component passes and has full coverage

Manual Testing:
1. Start the Demo app and import the Icon and Button component in `app.ts`:
```ts
import { UswdsIcon, UswdsButton } from 'ngx-uswds-lib';
```
2. Paste the following examples in ```app.html```:

```html
<a href="/uswds" style="align-self: flex-start;">
   <ngx-uswds-icon name="twitter"></ngx-uswds-icon>
   USWDS' Twitter account
</a>  

<a href="/uswds" style="align-self: flex-start;">
    <ngx-uswds-icon name="closed_caption" title="Open closed captions"></ngx-uswds-icon>
</a>

<a href="/uswds" style="align-self: flex-start;">
    <ngx-uswds-icon name="delete" title="Delete item"></ngx-uswds-icon>
</a>

<ngx-uswds-button type="submit">
    <ngx-uswds-icon name="content_copy"></ngx-uswds-icon>
    Copy text
</ngx-uswds-button>
```
*Note: Above parent elements have `style="align-self: flex-start;"` due to the demo app's demo-content-section class impacting the focus indicator's width*

3. Confirm the following checklist:
- [ ] All icon images render (one with accompanied text, two by themselves, and one within a button)
- [ ] Changing an icon's `name` to any of the icons listed on [this USWDS page](https://designsystem.digital.gov/components/icon/) renders the correct icon
- [ ] Adding `[size]="some width"` to the icons changes the icon's size. Try the widths: 3-9.
- [ ] Adding `class="some text color class"` to any of the `<a>` tags changes the icon's color. Try any of the text color classes on [this USWDS page](https://designsystem.digital.gov/utilities/color/#text-color-2).
- [ ] Adding `buttonStyle="AccentCool"` or any button style to the button component makes the icon change color.

4. Confirm the following accessibility checklist: 
- [ ] It is possible to navigate to each icon using tab and open the links with enter
- [ ] There is visual indication of focus for each icon

For the first (top) and last (bottom) icons:
- [ ] `<svg>` has the decorative icon attributes `aria-hidden="true", role="img", focusable="false"`
- [ ] Shows its accompanying text in ANDI Output when focused on

For the second and third icons:
- [ ] `<svg>` has only the attribute `role="img"` 
- [ ] `<svg>`'s `aria-labelledby` each contain a unique id from its nested `<title>`
- [ ] ANDI Output shows whatever `title` input is set to